### PR TITLE
Use jgit's UserConfig to get info about author.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ bin
 .classpath
 .project
 
+## netbeans metadata files
+.nb-gradle/private/
+.nb-gradle/profiles/private/
+
 ## generic files
 *~
 *.lock

--- a/src/main/java/me/cmoz/gradle/snapshot/GitSCMCommand.java
+++ b/src/main/java/me/cmoz/gradle/snapshot/GitSCMCommand.java
@@ -87,11 +87,12 @@ class GitSCMCommand implements SCMCommand {
             // git commit time in sec and java datetime is in ms
             final Date commitTime = new Date(revCommit.getCommitTime() * 1000L);
             final PersonIdent ident = revCommit.getAuthorIdent();
+            final UserConfig userConf = conf.get(UserConfig.KEY);
 
             return Commit.builder()
                     .buildTime(sdf.format(new Date()))
-                    .buildAuthorName(conf.getString("user", null, "name"))
-                    .buildAuthorEmail(conf.getString("user", null, "email"))
+                    .buildAuthorName(userConf.getAuthorName())
+                    .buildAuthorEmail(userConf.getAuthorEmail())
                     .branchName(repo.getBranch())
                     .commitId(revCommit.getName())
                     .commitTime(sdf.format(commitTime))

--- a/src/test/groovy/me/cmoz/gradle/snapshot/SnapshotTaskGitTest.groovy
+++ b/src/test/groovy/me/cmoz/gradle/snapshot/SnapshotTaskGitTest.groovy
@@ -15,11 +15,13 @@
  */
 package me.cmoz.gradle.snapshot
 
+import org.eclipse.jgit.util.SystemReader
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 
 import static org.junit.Assert.*
@@ -89,6 +91,52 @@ class SnapshotTaskGitTest {
         assertEquals("master", properties.get(Commit.BRANCH))
         assertEquals("chris@cmoz.me", properties.get(Commit.BUILD_USER_EMAIL))
         assertEquals("Chris Molozian", properties.get(Commit.BUILD_USER_NAME))
+    }
+
+    static class CustomEnv extends SystemReader {
+        @Delegate
+        def SystemReader delegate
+        def customEnv = [:]
+
+        @Override
+        public String getenv(String variable) {
+            customEnv[variable] ?: delegate.getenv(variable)
+        }
+
+        def static withenv(def key, def value, def closure) {
+            def prev = SystemReader.instance
+
+            def cust = new CustomEnv()
+            cust.delegate = prev
+            cust.@customEnv[key] = value
+
+            try {
+                SystemReader.instance = cust
+                closure.call()
+            } finally {
+                SystemReader.instance = prev
+            }
+        }
+    }
+
+    @Test
+    @Ignore("https://bugs.eclipse.org/bugs/show_bug.cgi?id=460586")
+    void "Should read author's name from environment variables"() {
+        def expected = 'The author is in another castle'
+        CustomEnv.withenv('GIT_AUTHOR_NAME', expected) {
+            project.tasks.getByName(SnapshotPlugin.SNAPSHOT_TASK_NAME).execute()
+            assertEquals(expected, project.properties[Commit.BUILD_USER_NAME])
+        }
+    }
+
+    @Test
+    @Ignore("https://bugs.eclipse.org/bugs/show_bug.cgi?id=460586")
+    void "Should read author's email from environment variables"() {
+        def expected = 'this-is-not-my-email@author.im'
+        CustomEnv.withenv('GIT_AUTHOR_EMAIL', expected) {
+            project.tasks.getByName(SnapshotPlugin.SNAPSHOT_TASK_NAME).execute()
+            assertEquals(expected, project.properties[Commit.BUILD_USER_EMAIL])
+        }
     }
 
 }


### PR DESCRIPTION
Not only this seems as the correct way to do it, but it's vital when you don't have any author in git local/global config and use `GIT_` environment variables only.

Also note that this may not work as expected in some cases due to a bug in jgit (url mentioned in tests) but at least it uses env vars at some point.
